### PR TITLE
fix: Filter empty string ICE candidates

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,7 +18,11 @@ const gatherIceCandidates = () => {
         rtc.onicecandidate = (entry) => {
             candidates.push(entry.candidate);
             if (rtc.iceGatheringState === 'complete') {
-                resolve(candidates.filter(Boolean).map(entry => entry.candidate));
+                resolve(candidates
+                    .filter(Boolean)
+                    .map(entry => entry.candidate)
+                    .filter(Boolean)
+                );
                 clearTimeout(id);
             }
         }


### PR DESCRIPTION
Firefox (104.0.2 / Linux) will add an entry with empty candidate, like:
```
RTCIceCandidate {
  candidate: "",
  sdpMLineIndex: 0,
  sdpMid: "0",
  usernameFragment: "b1104e3c",
}
```

Blocking the test over parsing errors.
![image](https://user-images.githubusercontent.com/497556/197743603-f0965289-4413-4648-96fc-5f28ce70d534.png)